### PR TITLE
site_selector: Add redirect capabilites

### DIFF
--- a/src/swamid_plugins/site_selector/__init__.py
+++ b/src/swamid_plugins/site_selector/__init__.py
@@ -43,7 +43,7 @@ class SiteSelector(ResponseMicroService):
             raise Error(error_context)
         query_string = urlencode({
             "user_id": internal_data.subject_id,
-            "displayname": (internal_data.attribute.get("displayname") or ["Unknown"])[0],
+            "displayname": (internal_data.attributes.get("displayname") or ["Unknown"])[0],
             "timestamp": internal_data.auth_info.timestamp,
             "issuer": internal_data.auth_info.issuer,
             "service": service_id,

--- a/src/swamid_plugins/site_selector/__init__.py
+++ b/src/swamid_plugins/site_selector/__init__.py
@@ -59,9 +59,12 @@ class SiteSelector(ResponseMicroService):
             "session_id":
             context.state.session_id
         }
-        query_string = urlencode(
-            {"context": base64.b64encode(json.dumps(context).encode("utf-8"))})
-        return Redirect(self.redirect_url + f'?{query_string}')
+        context_ser = json.dumps(payload, separators=(",", ":"))
+        context_ser_bytes = context_ser.encode("utf-8")
+        context_enc_bytes = base64.urlsafe_b64encode(context_ser_bytes)
+        context_enc = context_enc_bytes.decode("utf-8")
+        query_string = urlencode({"context": context_enc})
+        return Redirect(f"{self.redirect_url}?{query_string}")
 
 
 def evaluate_rule(rule, attributes):

--- a/src/swamid_plugins/site_selector/__init__.py
+++ b/src/swamid_plugins/site_selector/__init__.py
@@ -1,7 +1,9 @@
 from re import match as match_regex
+from urllib.parse import urlencode
 
 from satosa.exception import SATOSAError
 from satosa.micro_services.base import ResponseMicroService
+from satosa.response import Redirect
 
 
 class Error(SATOSAError):
@@ -9,21 +11,19 @@ class Error(SATOSAError):
 
 
 class SiteSelector(ResponseMicroService):
+
     def __init__(self, config, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # TODO: validate configuration format
         self.access_rules = config.get("access_rules", {})
-        self.access_rules_default = (
-            self.access_rules.pop("", None)
-            or self.access_rules.pop("default", None)
-        )
+        self.redirect_url = config.get("redirect_url", None)
+        self.access_rules_default = (self.access_rules.pop("", None)
+                                     or self.access_rules.pop("default", None))
 
     def process(self, context, internal_data):
         service_id = internal_data.requester
-        access_rules_for_service = (
-            self.access_rules.get(service_id)
-            or self.access_rules_default
-        )
+        access_rules_for_service = (self.access_rules.get(service_id)
+                                    or self.access_rules_default)
 
         # evaluate each rule set for this particular service
         for rule in access_rules_for_service:
@@ -32,21 +32,29 @@ class SiteSelector(ResponseMicroService):
             if result:
                 return super().process(context, internal_data)
 
-        # no rule was successful; abort processing the response any further
-        error_context = {
-            "message": "Failed to satisfy any rule for accessing the service.",
+        # no rule was successful; either redirect or abort processing the response any further
+        if not self.redirect_url:
+            error_context = {
+                "message":
+                "Failed to satisfy any rule for accessing the service.",
+                "service": service_id,
+                "rules": access_rules_for_service,
+            }
+            raise Error(error_context)
+        query_string = urlencode({
+            "user_id": internal_data.subject_id,
+            "displayname": (internal_data.attribute.get("displayname") or ["Unknown"])[0],
+            "timestamp": internal_data.auth_info.timestamp,
+            "issuer": internal_data.auth_info.issuer,
             "service": service_id,
-            "rules": access_rules_for_service,
-        }
-        raise Error(error_context)
+            "session_id": context.state.session_id
+        })
+        return Redirect(self.redirect_url + f'?{query_string}')
 
 
 def evaluate_rule(rule, attributes):
     regex = rule["match"]
     attr = rule["attribute"]
     attr_values = attributes.get(attr, [])
-    satisfied = any(
-        match_regex(regex, v)
-        for v in attr_values
-    )
+    satisfied = any(match_regex(regex, v) for v in attr_values)
     return satisfied


### PR DESCRIPTION
With this patch set we get the possibility to set a redirect_url in the config of the micro service. That will result in a redirect to this URL if the authentication is not successful.

The redirect looks like this:
```
https://portal.drive.test.sunet.se/?context=eyJ1c2VyX2lkIjogInRlbmUzMjUzQHN1LnNlIiwgImRpc3BsYXluYW1lIjogIlRlc3QgTmV4dGNsb3VkIiwgInRpbWVzdGFtcCI6ICIyMDI0LTAyLTI4VDEwOjE1OjQyLjI2M1oiLCAiaXNzdWVyIjogImh0dHBzOi8vaWRwLml0LnN1LnNlL2lkcC9zaGliYm9sZXRoIiwgInNlcnZpY2UiOiAiaHR0cHM6Ly9zdW5ldC5kcml2ZS50ZXN0LnN1bmV0LnNlL2luZGV4LnBocC9hcHBzL3VzZXJfc2FtbC9zYW1sL21ldGFkYXRhIiwgInNlc3Npb25faWQiOiAidXJuOnV1aWQ6MjA2YmE1Y2EtYzAxZC00MTBhLWE5ZGEtYmYyNGJiOWI4NTdhIn0%3D
```
The context-parameter in this url is a url- and base64-encoded json string that looks like this when decoded:

```
{"user_id": "tene3253@su.se", "displayname": "Test Nextcloud", "timestamp": "2024-02-28T10:15:42.263Z", "issuer": "https://idp.it.su.se/idp/shibboleth", "service": "https://sunet.drive.test.sunet.se/index.php/apps/user_saml/saml/metadata", "session_id": "urn:uuid:206ba5ca-c01d-410a-a9da-bf24bb9b857a"}
```

This code has been successfully tested in Sunet Drive satosa running version 8.4.0.